### PR TITLE
Fix for missing sub collections in sections when usage type does not completely match

### DIFF
--- a/src/RapidCMS.Core/Enums/UsageType.cs
+++ b/src/RapidCMS.Core/Enums/UsageType.cs
@@ -21,6 +21,8 @@ namespace RapidCMS.Core.Enums
         // Root = root of page
         Root = 2097152,
         // NotRoot = embedded collection on a page
-        NotRoot = 4194304
+        NotRoot = 4194304,
+
+        ViewOrEdit = View | Edit
     }
 }

--- a/src/RapidCMS.Core/Extensions/EnumExtensions.cs
+++ b/src/RapidCMS.Core/Extensions/EnumExtensions.cs
@@ -23,7 +23,18 @@ namespace RapidCMS.Core.Extensions
             return default;
         }
 
-        public static UsageType FindSupportedUsageType(this UsageType supportsUsageType, UsageType requestedUsageType) 
-            => supportsUsageType & requestedUsageType;
+        public static UsageType FindSupportedUsageType(this UsageType supportsUsageType, UsageType requestedUsageType)
+        {
+            var supportedUsageType = (supportsUsageType & requestedUsageType) & UsageType.ViewOrEdit;
+
+            if (supportedUsageType > 0)
+            {
+                return supportedUsageType;
+            }
+            else
+            {
+                return UsageType.View | (requestedUsageType & ~UsageType.ViewOrEdit);
+            } 
+        }
     }
 }

--- a/src/RapidCMS.Core/Resolvers/UI/BaseUIResolver.cs
+++ b/src/RapidCMS.Core/Resolvers/UI/BaseUIResolver.cs
@@ -70,8 +70,7 @@ namespace RapidCMS.Core.Resolvers.UI
             });
 
             var subCollections = pane.SubCollectionLists
-                // do not display sub collections that do not support it in that view (like a List View embedded in Node Editor, Node Editors always want List Editors (for now))
-                .Where(subCollection => (subCollection.SupportsUsageType & editContext.UsageType & (UsageType.Edit | UsageType.View)) > UsageType.None)
+                .Where(subCollection => subCollection.SupportsUsageType.FindSupportedUsageType(editContext.UsageType) > UsageType.None)
                 .Select(subCollection =>
                 {
                     var parentPath = ParentPath.AddLevel(editContext.Parent?.GetParentPath(), editContext.RepositoryAlias, editContext.Entity.Id!);
@@ -88,8 +87,7 @@ namespace RapidCMS.Core.Resolvers.UI
                 });
 
             var relatedCollections = pane.RelatedCollectionLists
-                // do not display sub collections that do not support it in that view (like a List View embedded in Node Editor, Node Editors always want List Editors (for now))
-                .Where(relatedCollection => (relatedCollection.SupportsUsageType & editContext.UsageType & (UsageType.Edit | UsageType.View)) > UsageType.None)
+                .Where(relatedCollection => relatedCollection.SupportsUsageType.FindSupportedUsageType(editContext.UsageType) > UsageType.None)
                 .Select(relatedCollection =>
                 {
                     var parentPath = ParentPath.AddLevel(editContext.Parent?.GetParentPath(), editContext.RepositoryAlias, editContext.Entity.Id!);


### PR DESCRIPTION
 - CMS should allow Edit screens be used in Views, and Views be used in Edit screens if no alternative is provided.
 - Fixes #164